### PR TITLE
Fix TypeError when using dynamic version

### DIFF
--- a/src/pdm_bump/config.py
+++ b/src/pdm_bump/config.py
@@ -127,7 +127,7 @@ class ProjectMetaData:  # pylint: disable=R0903
 
     @property
     def is_dynamic_version(self) -> bool:
-        return ConfigKeys().VERSION in self.__meta_data.dynamic
+        return ConfigKeys.VERSION in self.__meta_data.dynamic
 
 
 class _ConfigSection(IntEnum):


### PR DESCRIPTION
Full message was "TypeError: EnumType.__call__() missing 1 required positional argument: 'value'".