### PR TITLE
build: Fix gitlint error during update

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -93,7 +93,7 @@ jobs:
           add-paths: |
             pyproject.toml
             pdm.lock
-          commit-message: >
+          commit-message: |
             ${{ env.GIT_PDM_TITLE }}
 
             ${{ env.PDM_UPDATED_PACKAGES_NAMES }}


### PR DESCRIPTION
The second line was not empty due to a pipeline authoring error