### PR TITLE
chore: Change metadata license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "tomli-w>=1.0.0",
 ]
 requires-python = ">=3.9"
-license = "MIT"
+license = { text = "MIT" }
 
 [project.license-files]
 paths = [


### PR DESCRIPTION
According to PEP 639, the license text must be
an object / hash instead of a text

PDM may show issues due to this missing field,
e.g. when running pdm show