### PR TITLE
chore: Updated 5 dependencies in pdm.lock

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -89,15 +89,36 @@ extras = ["filecache"]
 requires_python = ">=3.6"
 summary = "httplib2 caching for requests"
 dependencies = [
-    "cachecontrol==0.12.11",
+    "CacheControl==0.12.11",
     "lockfile>=0.9",
 ]
 
 [[package]]
 name = "cachetools"
-version = "5.3.0"
-requires_python = "~=3.7"
+version = "5.3.1"
+requires_python = ">=3.7"
 summary = "Extensible memoizing collections and decorators"
+
+[[package]]
+name = "cacheyou"
+version = "23.3"
+requires_python = ">=3.7"
+summary = "httplib2 caching for requests"
+dependencies = [
+    "msgpack>=0.5.2",
+    "requests",
+]
+
+[[package]]
+name = "cacheyou"
+version = "23.3"
+extras = ["filecache"]
+requires_python = ">=3.7"
+summary = "httplib2 caching for requests"
+dependencies = [
+    "cacheyou==23.3",
+    "filelock>=3.8.0",
+]
 
 [[package]]
 name = "certifi"
@@ -410,12 +431,12 @@ summary = "Python Build Reasonableness"
 
 [[package]]
 name = "pdm"
-version = "2.6.1"
+version = "2.7.0"
 requires_python = ">=3.7"
 summary = "A modern Python package and dependency manager supporting the latest PEP standards"
 dependencies = [
     "blinker",
-    "cachecontrol[filecache]>=0.12.11",
+    "cacheyou[filecache]",
     "certifi",
     "findpython>=0.2.2",
     "importlib-metadata>=3.6; python_version < \"3.10\"",
@@ -845,20 +866,20 @@ summary = "Style preserving TOML library"
 
 [[package]]
 name = "tox"
-version = "4.5.1"
+version = "4.5.2"
 requires_python = ">=3.7"
 summary = "tox is a generic virtualenv management and test command line tool"
 dependencies = [
     "cachetools>=5.3",
     "chardet>=5.1",
     "colorama>=0.4.6",
-    "filelock>=3.11",
+    "filelock>=3.12",
     "packaging>=23.1",
-    "platformdirs>=3.2",
+    "platformdirs>=3.5.1",
     "pluggy>=1",
     "pyproject-api>=1.5.1",
     "tomli>=2.0.1; python_version < \"3.11\"",
-    "virtualenv>=20.21",
+    "virtualenv>=20.23",
 ]
 
 [[package]]
@@ -992,9 +1013,13 @@ content_hash = "sha256:d850576a18f48eca5bfc313b33da932d4ef2d5b6fc67268a6cdb70ecf
     {url = "https://files.pythonhosted.org/packages/46/9b/34215200b0c2b2229d7be45c1436ca0e8cad3b10de42cfea96983bd70248/CacheControl-0.12.11.tar.gz", hash = "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"},
     {url = "https://files.pythonhosted.org/packages/83/63/15ce47ede5b03657e920f3f006e56ca9a16f7873978146f2f77e297bdd22/CacheControl-0.12.11-py2.py3-none-any.whl", hash = "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b"},
 ]
-"cachetools 5.3.0" = [
-    {url = "https://files.pythonhosted.org/packages/4d/91/5837e9f9e77342bb4f3ffac19ba216eef2cd9b77d67456af420e7bafe51d/cachetools-5.3.0.tar.gz", hash = "sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14"},
-    {url = "https://files.pythonhosted.org/packages/db/14/2b48a834d349eee94677e8702ea2ef98b7c674b090153ea8d3f6a788584e/cachetools-5.3.0-py3-none-any.whl", hash = "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"},
+"cachetools 5.3.1" = [
+    {url = "https://files.pythonhosted.org/packages/9d/8b/8e2ebf5ee26c21504de5ea2fb29cc6ae612b35fd05f959cdb641feb94ec4/cachetools-5.3.1.tar.gz", hash = "sha256:dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b"},
+    {url = "https://files.pythonhosted.org/packages/a9/c9/c8a7710f2cedcb1db9224fdd4d8307c9e48cbddc46c18b515fefc0f1abbe/cachetools-5.3.1-py3-none-any.whl", hash = "sha256:95ef631eeaea14ba2e36f06437f36463aac3a096799e876ee55e5cdccb102590"},
+]
+"cacheyou 23.3" = [
+    {url = "https://files.pythonhosted.org/packages/41/e1/1864f74d5ea8edfe4e217ce6cf81d04989b32ef949487b289753227a64af/cacheyou-23.3-py3-none-any.whl", hash = "sha256:eeed1d071495ed59be0049c3897a4c3c056c4b30f751b3197b823c518bcac604"},
+    {url = "https://files.pythonhosted.org/packages/8e/6e/8a9d13f938789b29e89b78cfeb9d0a9e002c67272ead73060c8306b74fc8/cacheyou-23.3.tar.gz", hash = "sha256:7e408f15f4978fea2247734b308621f75f7fe169b461679519c72e8a85d61d5d"},
 ]
 "certifi 2023.5.7" = [
     {url = "https://files.pythonhosted.org/packages/93/71/752f7a4dd4c20d6b12341ed1732368546bc0ca9866139fe812f6009d9ac7/certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
@@ -1393,9 +1418,9 @@ content_hash = "sha256:d850576a18f48eca5bfc313b33da932d4ef2d5b6fc67268a6cdb70ecf
     {url = "https://files.pythonhosted.org/packages/01/06/4ab11bf70db5a60689fc521b636849c8593eb67a2c6bdf73a16c72d16a12/pbr-5.11.1-py2.py3-none-any.whl", hash = "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b"},
     {url = "https://files.pythonhosted.org/packages/02/d8/acee75603f31e27c51134a858e0dea28d321770c5eedb9d1d673eb7d3817/pbr-5.11.1.tar.gz", hash = "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"},
 ]
-"pdm 2.6.1" = [
-    {url = "https://files.pythonhosted.org/packages/23/ed/1407244ce1f0dab78a666b80b88acbb8c0a0c52d549c585ee540c91bebdb/pdm-2.6.1-py3-none-any.whl", hash = "sha256:9d1c92a0199536f1c971bced8d33f9188eeb70edff6469d00cdd812d4426498a"},
-    {url = "https://files.pythonhosted.org/packages/85/5a/2002159c9b871b32619d6ba1ab8738ac6f212a26ce3e1e53d2515eb35173/pdm-2.6.1.tar.gz", hash = "sha256:105958849a2f8d9aa9ef2183a2c50eae9eb4ac47fc81272cd504fdd9c90edea2"},
+"pdm 2.7.0" = [
+    {url = "https://files.pythonhosted.org/packages/66/c2/fdbf899e84cfdf8068d022296426ce9e02d58e280e93902c6e2027aeb4a4/pdm-2.7.0.tar.gz", hash = "sha256:e1dcaefe778c157fd4d51b88d19101cdd6ce3481ef756cafa72d46bb988c01c8"},
+    {url = "https://files.pythonhosted.org/packages/94/37/c72461e521d1efc9631caa53b639df6453dbc78c114299d908119987f03f/pdm-2.7.0-py3-none-any.whl", hash = "sha256:9a79988a71ea666fe7ff41fd0541bf94f11d8f58cd4e9e67c9e36f46e4a6fc39"},
 ]
 "pep8-naming 0.13.3" = [
     {url = "https://files.pythonhosted.org/packages/4f/48/9533518e0394fb858ac2b4b55fe18f24aa33c87c943f691336ec842d9728/pep8_naming-0.13.3-py3-none-any.whl", hash = "sha256:1a86b8c71a03337c97181917e2b472f0f5e4ccb06844a0d6f0a33522549e7a80"},
@@ -1712,9 +1737,9 @@ content_hash = "sha256:d850576a18f48eca5bfc313b33da932d4ef2d5b6fc67268a6cdb70ecf
     {url = "https://files.pythonhosted.org/packages/10/37/dd53019ccb72ef7d73fff0bee9e20b16faff9658b47913a35d79e89978af/tomlkit-0.11.8.tar.gz", hash = "sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3"},
     {url = "https://files.pythonhosted.org/packages/ef/a8/b1c193be753c02e2a94af6e37ee45d3378a74d44fe778c2434a63af92731/tomlkit-0.11.8-py3-none-any.whl", hash = "sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171"},
 ]
-"tox 4.5.1" = [
-    {url = "https://files.pythonhosted.org/packages/1a/d0/db430b1b14724899f96cd832d71ae98de72bbe839b00d4537941807faac1/tox-4.5.1.tar.gz", hash = "sha256:5a2eac5fb816779dfdf5cb00fecbc27eb0524e4626626bb1de84747b24cacc56"},
-    {url = "https://files.pythonhosted.org/packages/29/eb/5a56994b37d9141a6c7fa6ddb5c76a50b234a424eae4e79c56f33b61c686/tox-4.5.1-py3-none-any.whl", hash = "sha256:d25a2e6cb261adc489604fafd76cd689efeadfa79709965e965668d6d3f63046"},
+"tox 4.5.2" = [
+    {url = "https://files.pythonhosted.org/packages/71/da/0cb03d5659fc754dc467489acd66cdf8042e30b1255c59f71790660e0ce1/tox-4.5.2.tar.gz", hash = "sha256:ad87fb7a10ef476afb6eb7e408808057f42976ef0d30ad5fe023099ba493ce58"},
+    {url = "https://files.pythonhosted.org/packages/eb/2a/1cf03754356acd0fa2d89c825878e499072488a455e57554db262d9bcd93/tox-4.5.2-py3-none-any.whl", hash = "sha256:f1a9541b292aa0449f6c7bb67dc0073f25f9086413c3922fe47f5168cbf7b2f4"},
 ]
 "tox-pdm 0.6.1" = [
     {url = "https://files.pythonhosted.org/packages/57/42/c437d69c3b884c58027999e524c91716ac355048284be771d810d80ceed1/tox-pdm-0.6.1.tar.gz", hash = "sha256:952ea67f2ec891f11eb00749f63fc0f980384435ca782c448d154390f9f42f5e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdm-bump"
-version = "0.7.1.dev18"
+version = "0.7.1.dev19"
 readme = "README.md"
 description = "A plugin for PDM providing the ability to modify the version according to PEP440"
 authors = [


### PR DESCRIPTION
Packages to add:
  - cacheyou 23.3
Packages to update:
  - cachetools 5.3.0 -> 5.3.1
  - pdm 2.6.1 -> 2.7.0
  - tox 4.5.1 -> 4.5.2