### PR TITLE
fix: Cannot get `build-backend` while is `pdm-backend` when using dynamic version

### DIFF
--- a/src/pdm_bump/dynamic.py
+++ b/src/pdm_bump/dynamic.py
@@ -125,7 +125,7 @@ class DynamicVersionConfig:
                 pattern=DEFAULT_REGEX,
             )
         if (
-            project_config.get_pyproject_metadata(ConfigKeys.BUILD_BACKEND)
+            project_config.get_pyproject_build_system(ConfigKeys.BUILD_BACKEND)
             == ConfigValues.BUILD_BACKEND_PDM_BACKEND
         ):
             if (


### PR DESCRIPTION
I'm using dynamic version.

When `build-backend` is `pdm-backend`, because of this:

https://github.com/carstencodes/pdm-bump/blob/f6a504774eedd8367a5cb607c84cfaa75ca13740/src/pdm_bump/dynamic.py#L127-L130

This will result in the dynamic version not being found.

This PR fixed this problem by changing `get_pyproject_metadata` to `get_pyproject_build_system`
