### PR TITLE
fix!: Use another configuration key

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -29,7 +29,7 @@ jobs:
           version: ${{ env.pdm_version }}
           prerelease: true
           enable-pep582: true
-          allow-python-prereleases: false 
+          allow-python-prereleases: false
       - name: Disable update check
         shell: bash
         run: pdm config check_update false
@@ -67,7 +67,8 @@ jobs:
         id: detect-changes
         shell: bash
         run: |
-          if [[ `git status --porcelain` ]]; then
+          _no_changed_files=$(git status --porcelain | wc -l)
+          if [ $_no_changed_files -ne 0 ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdm-bump"
-version = "0.7.1.dev11"
+version = "0.7.2"
 readme = "README.md"
 description = "A plugin for PDM providing the ability to modify the version according to PEP440"
 authors = [

--- a/src/pdm_bump/core/config.py
+++ b/src/pdm_bump/core/config.py
@@ -378,7 +378,7 @@ class Config:
         ):
             section_key = ["tool", "pdm"]
             if _ConfigSection.PLUGIN_CONFIG == section:
-                section_key.extend(["plugins", "bump"])
+                section_key.extend(["bump-plugin"])
             section_key = tuple(section_key)
         elif _ConfigSection.BUILD_SYSTEM == section:
             section_key = ("build-system",)


### PR DESCRIPTION
The configuration key cannot be tools.pdm.plugins.bump, as tools.pdm.plugins must be a list, not a table.

Closes #109