### PR TITLE
chore: Updated 4 dependencies in pdm.lock

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -909,12 +909,12 @@ files = [
 
 [[package]]
 name = "packageurl-python"
-version = "0.11.1"
+version = "0.11.2"
 requires_python = ">=3.7"
 summary = "A purl aka. Package URL parser and builder"
 files = [
-    {file = "packageurl-python-0.11.1.tar.gz", hash = "sha256:bbcc53d2cb5920c815c1626c75992f319bfc450b73893fa7bd8aac5869aa49fe"},
-    {file = "packageurl_python-0.11.1-py3-none-any.whl", hash = "sha256:4bad1d3ea4feb5e7a1db5ca8fb690ac9c82ab18e08d500755947b853df68817d"},
+    {file = "packageurl-python-0.11.2.tar.gz", hash = "sha256:01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471"},
+    {file = "packageurl_python-0.11.2-py3-none-any.whl", hash = "sha256:799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84"},
 ]
 
 [[package]]
@@ -949,14 +949,14 @@ files = [
 
 [[package]]
 name = "pdm"
-version = "2.8.0"
+version = "2.8.1"
 requires_python = ">=3.7"
 summary = "A modern Python package and dependency manager supporting the latest PEP standards"
 dependencies = [
     "blinker",
     "cachecontrol[filecache]>=0.13.0",
     "certifi",
-    "findpython>=0.3.0",
+    "findpython<1.0.0a0,>=0.3.0",
     "importlib-metadata>=3.6; python_version < \"3.10\"",
     "installer<0.8,>=0.7",
     "packaging!=22.0,>=20.9",
@@ -969,12 +969,12 @@ dependencies = [
     "shellingham>=1.3.2",
     "tomli>=1.1.0; python_version < \"3.11\"",
     "tomlkit<1,>=0.11.1",
-    "unearth>=0.9.0",
+    "unearth>=0.10.0",
     "virtualenv>=20",
 ]
 files = [
-    {file = "pdm-2.8.0-py3-none-any.whl", hash = "sha256:5ddd0921de8054abaeb70149b63a0c29dfa5d12c561b3a774cf04c43a85f6f08"},
-    {file = "pdm-2.8.0.tar.gz", hash = "sha256:060b1628fda465f2c41e064d212ca9eba630c346a3305e115ae23a4c2cf024da"},
+    {file = "pdm-2.8.1-py3-none-any.whl", hash = "sha256:46065b4c2455d3f55e48e4c47b7b9362c4a852dac290c425e643936d2fe8fc6c"},
+    {file = "pdm-2.8.1.tar.gz", hash = "sha256:90366bc6d3f8f0e7ba4271efa0f78dae04f1634aec5aa44784d93e2bd4edcad8"},
 ]
 
 [[package]]
@@ -1015,7 +1015,7 @@ files = [
 
 [[package]]
 name = "pip-audit"
-version = "2.6.0"
+version = "2.6.1"
 requires_python = ">=3.7"
 summary = "A tool for scanning Python environments for known vulnerabilities"
 dependencies = [
@@ -1030,8 +1030,8 @@ dependencies = [
     "toml>=0.10",
 ]
 files = [
-    {file = "pip_audit-2.6.0-py3-none-any.whl", hash = "sha256:49e97e3d6663d2ed0c00b7a7c468afcb816beb3988f32f8496d3fe3927cfd627"},
-    {file = "pip_audit-2.6.0.tar.gz", hash = "sha256:6431c363efa80ef52c2599197c5b8a39ff8708ce316624b97fa35b5cdf493118"},
+    {file = "pip_audit-2.6.1-py3-none-any.whl", hash = "sha256:8a32bb67dca6a76c244bbccebed562c0f6957b1fc9d34d59a9ec0fbff0672ae0"},
+    {file = "pip_audit-2.6.1.tar.gz", hash = "sha256:55c9bd18b0fe3959f73397db08d257c6012ad1826825e3d74cb6c3f79e95c245"},
 ]
 
 [[package]]
@@ -1151,11 +1151,11 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.4"
+version = "2.17.5"
 requires_python = ">=3.7.2"
 summary = "python code static checker"
 dependencies = [
-    "astroid<=2.17.0-dev0,>=2.15.4",
+    "astroid<=2.17.0-dev0,>=2.15.6",
     "colorama>=0.4.5; sys_platform == \"win32\"",
     "dill>=0.2; python_version < \"3.11\"",
     "dill>=0.3.6; python_version >= \"3.11\"",
@@ -1167,8 +1167,8 @@ dependencies = [
     "typing-extensions>=3.10.0; python_version < \"3.10\"",
 ]
 files = [
-    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
-    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
+    {file = "pylint-2.17.5-py3-none-any.whl", hash = "sha256:73995fb8216d3bed149c8d51bba25b2c52a8251a2c8ac846ec668ce38fab5413"},
+    {file = "pylint-2.17.5.tar.gz", hash = "sha256:f7b601cbc06fef7e62a754e2b41294c2aa31f1cb659624b9a85bcba29eaf8252"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdm-bump"
-version = "0.7.3.dev3"
+version = "0.7.3.dev4"
 readme = "README.md"
 description = "A plugin for PDM providing the ability to modify the version according to PEP440"
 authors = [


### PR DESCRIPTION
Packages to update:
  - packageurl-python 0.11.1 -> 0.11.2
  - pdm 2.8.0 -> 2.8.1
  - pip-audit 2.6.0 -> 2.6.1
  - pylint 2.17.4 -> 2.17.5