### PR TITLE
fix: typo which generates useless error message

### DIFF
--- a/src/pdm_bump/actions/base.py
+++ b/src/pdm_bump/actions/base.py
@@ -367,7 +367,7 @@ class ActionRegistry:
         if selected_command not in self.__items:
             raise ValueError(
                 f"Failed to get command {selected_command}. "
-                + "Valid values are {', '.join(self.__items.keys())}."
+                + f"Valid values are {', '.join(self.__items.keys())}."
             )
 
         clazz: type[ActionBase] = self.__items[selected_command]


### PR DESCRIPTION
Format string was not marked correctly

Originally authored by Bill Chen (github.com/FYWinds)