### PR TITLE
fix: Remove a debugging step

### DIFF
--- a/src/pdm_bump/actions/base.py
+++ b/src/pdm_bump/actions/base.py
@@ -415,7 +415,6 @@ class ActionRegistry:
         }
 
         kwargs.update(allowed_kwargs)
-        print(args)
 
         command: "ActionBase" = clazz.create_from_command(**kwargs)
 


### PR DESCRIPTION
Print-statement is superfluous