### PR TITLE
fix: Use venv as backend

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Disable update check
         shell: bash
         run: pdm config check_update false
+      - name: Use venv as backend
+        shell: bash
+        run: pdm config venv.backend venv
       - name: Install all dependencies from lock file
         shell: bash
         run: pdm install -G:all


### PR DESCRIPTION
virtualenv is the default backend, but this fails for uncertain reasons