### PR TITLE
Make CLI in line with intended default for increment_micro

### DIFF
--- a/src/pdm_bump/actions/preview.py
+++ b/src/pdm_bump/actions/preview.py
@@ -80,11 +80,11 @@ class _PreReleaseIncrementingVersionModifier(VersionModifier):
 
         """
         sub_parser.add_argument(
-            "--micro",
-            action="store_true",
+            "--no-micro",
+            action="store_false",
             dest="increment_micro",
             help="When setting pre-release, specifies "
-            + "whether micro version shall "
+            + "that micro version shall not "
             + "be incremented as well",
         )
 

--- a/src/pdm_bump/actions/version_providers.py
+++ b/src/pdm_bump/actions/version_providers.py
@@ -182,7 +182,7 @@ class RatingBasedVersionPolicy(VersionPolicy):
                     self.__version.preview
                 )
                 modifier = PreReleaseIncrementingVersionModifier(
-                    self.__version, self, pre_release_part, False
+                    self.__version, self, pre_release_part, False, True
                 )
             else:
                 modifier = ResetNonSemanticPartsModifier(self.__version, self)
@@ -201,7 +201,7 @@ class RatingBasedVersionPolicy(VersionPolicy):
                 )
                 pre_release_part = self.__shift_preview_part(pre_release_part)
                 modifier = PreReleaseIncrementingVersionModifier(
-                    self.__version, self, pre_release_part, False
+                    self.__version, self, pre_release_part, False, True
                 )
         return modifier
 


### PR DESCRIPTION
@carstencodes I think this would fix #326,
but I'm not certain about any side effects.

A different solution would be to use store_const
and have different None handling, see e.g.
https://docs.python.org/3/library/argparse.html.
Again, not sure of side effects.