### PR TITLE
ci: Release without twine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,19 +36,18 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine pdm
+        pip install setuptools wheel pdm
         pdm install -G:all
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        PDM_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        PDM_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        pdm build
-        twine upload dist/*
+        pdm publish
 
   release:
     name: Create Release


### PR DESCRIPTION
Twine cannot use METADATA 2.4