### PR TITLE
chore: Bump version 0.9.9 to 0.9.9.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdm-bump"
-version = "0.9.9"
+version = "0.9.9.post1"
 readme = "README.md"
 description = "A plugin for PDM providing the ability to modify the version according to PEP440"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Created a commit with a new version 0.9.9.post1.
Previous version was 0.9.9.