### PR TITLE
ci: ignore python version file in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install pdm==${{ steps.setpdmversion.outputs.pdm_version }}
         pdm install -G:all
+      env:
+        PDM_PYTHON_VERSION: ${{ steps.setpyversion.outputs.python_version }}
     - name: Build and publish
       env:
         PDM_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdm-bump"
-version = "0.9.11.post1"
+version = "0.9.11.post2"
 readme = "README.md"
 description = "A plugin for PDM providing the ability to modify the version according to PEP440"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Issues while releasing 0.9.11.post1