### PR TITLE
chore: Bump version 0.9.13.dev22 to 0.9.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdm-bump"
-version = "0.9.13.dev22"
+version = "0.9.13"
 readme = "README.md"
 description = "A plugin for PDM providing the ability to modify the version according to PEP440"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Created a commit with a new version 0.9.13.
Previous version was 0.9.13.dev22.